### PR TITLE
add template API

### DIFF
--- a/lib/sendcloud.rb
+++ b/lib/sendcloud.rb
@@ -1,6 +1,7 @@
 require 'rest-client'
 require 'sendcloud/mail'
 require 'sendcloud/mail_list'
+require 'sendcloud/template'
 require 'sendcloud/stats'
 require 'sendcloud/unsubscribes'
 require 'sendcloud/bounces'

--- a/lib/sendcloud/template.rb
+++ b/lib/sendcloud/template.rb
@@ -1,0 +1,25 @@
+module Sendcloud
+
+  module Template
+
+    extend self
+
+    def add params
+      Sendcloud.post('template.add', params)
+    end
+    
+    def delete params
+      Sendcloud.post('template.delete', params)
+    end
+    
+    def get params
+      Sendcloud.get('template.get', params)
+    end
+    
+    def update params
+      Sendcloud.post('template.update', params)
+    end
+
+  end
+
+end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -1,0 +1,43 @@
+require File.expand_path('../spec_helper.rb', __FILE__)
+
+
+describe  Sendcloud::Template do
+
+  describe 'add/update/delete' do
+    it 'should return success when add template' do
+      response = Sendcloud::Template.add({
+                                          :invoke_name => 'testtemplate',
+                                          :name => 'Test Template',
+                                          :html => '<p>Test Email</p>',
+                                          :subject => "Template Subject",
+                                          :email_type => 1
+                                      })
+      expect(response['message']).to eq('success')
+      
+      response = Sendcloud::Template.update({ 
+                                          :invoke_name => 'testtemplate',
+                                          :name => 'Test Template (Updated)',
+                                          :html => '<p>Test Email Content Updated</p>',
+                                          :subject => "Template Subject (Updated)",
+                                          :email_type => 1
+                                      })
+      expect(response['message']).to eq('success')
+      expect(response['updateCount']).to eq(1)
+      
+      response = Sendcloud::Template.delete({
+                                          :invoke_name => 'testtemplate'
+                                      })
+      expect(response['message']).to eq('success')
+    end
+  end
+  
+  describe 'get' do
+    it 'should return success when get template' do
+      response = Sendcloud::Template.get({
+                                      })  
+
+      expect(response['message']).to eq('success')
+    end
+  end
+
+end


### PR DESCRIPTION
SendCloud released the new template API on July. This PR is to add the capability to CRUD templates. ref: http://sendcloud.sohu.com/doc/email/template_do/
